### PR TITLE
Edited Catchup Event

### DIFF
--- a/events/kiyo_spy_passive_events.txt
+++ b/events/kiyo_spy_passive_events.txt
@@ -58,13 +58,10 @@ event = {
 						NOT = { is_country = prev }
 						has_communications = prev
 						PREV = { NOT = { is_country_type = ascended_empire } }
-						OR = {
-							AND = {
+						AND = {
 								is_neighbor_of = prev
 								relative_power = { who = prev category = technology value >= superior }
 								relative_power = { who = prev category = capacity value >= superior }
-							}
-							relative_power = { who = prev category = all value >= overwhelming }
 						}
 					}
 				}


### PR DESCRIPTION
Removed the alternate OR condition from the event triggers that gave the catchup modifier if any country was 'overwhelming' in overall power.
Now, the only way to get the catchup event is to have a neighbour with both superior technology and economy to you.